### PR TITLE
Fix stdio transport console logging interference for Claude Desktop

### DIFF
--- a/bin/mcp-agent-social
+++ b/bin/mcp-agent-social
@@ -14,17 +14,17 @@ const distPath = join(__dirname, '..', 'dist', 'index.js');
 
 // Check if built files exist, if not, try to build them
 if (!existsSync(distPath)) {
-  console.log('Building project...');
+  process.stderr.write('Building project...\n');
   try {
     execSync('npm run build', { cwd: join(__dirname, '..'), stdio: 'inherit' });
   } catch (error) {
-    console.error('Failed to build project. Please run "npm run build" manually.');
+    process.stderr.write('Failed to build project. Please run "npm run build" manually.\n');
     process.exit(1);
   }
 }
 
 // Now import the main module
 import('../dist/index.js').catch((error) => {
-  console.error('Failed to start MCP Agent Social Server:', error.message);
+  process.stderr.write(`Failed to start MCP Agent Social Server: ${error.message}\n`);
   process.exit(1);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-agent-social",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-agent-social",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ async function shutdown(signal: string) {
 }
 
 main().catch((error) => {
-  console.error('Unhandled error:', error);
+  // Write to stderr to avoid polluting JSON-RPC stream in stdio mode
+  process.stderr.write(`Unhandled error: ${error}\n`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Modified logger to detect stdio mode and write to stderr instead of stdout
- Updated unhandled error handler to use stderr in stdio mode
- Fixed bin script console output to use stderr instead of stdout
- Fixed linting issues with template literals and unused variables

## Problem
MCP server works correctly with Claude Code CLI but fails when installed in Claude Desktop, producing JSON parsing errors due to console logging interfering with the JSON-RPC stream.

## Solution
The fix redirects all console output to stderr when in stdio mode, preventing JSON-RPC stream pollution that causes Claude Desktop parsing errors.

## Test plan
- [x] All existing tests pass (567/567)
- [x] TypeScript compilation succeeds
- [x] Pre-commit hooks pass
- [x] Code style checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error and status message handling to prevent interference with JSON-RPC streams when running in stdio mode. Messages are now directed to standard error output instead of standard output.

* **Refactor**
  * Updated logging behavior to conditionally write messages to standard error or use console methods based on the current transport mode, enhancing compatibility with different runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->